### PR TITLE
Fix: Auto aria-levels (Issue #45)

### DIFF
--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -10,7 +10,7 @@ export default function Flipcard (props) {
     _animation,
     onClick
   } = props;
-  const itemAriaLevel = _.isNumber(_ariaLevel) ? _ariaLevel + 1 : _ariaLevel;
+  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 : _ariaLevel;
   return (
     <div className="component__inner flipcard-audio__inner">
 

--- a/templates/flipcard.jsx
+++ b/templates/flipcard.jsx
@@ -10,7 +10,7 @@ export default function Flipcard (props) {
     _animation,
     onClick
   } = props;
-  const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 : _ariaLevel;
+ const itemAriaLevel = _.isNumber(_ariaLevel) && _ariaLevel !== 0 ? _ariaLevel + 1 : _ariaLevel;
   return (
     <div className="component__inner flipcard-audio__inner">
 


### PR DESCRIPTION
Fixes issue #45. 

Only likely to occur when courses are exported from the Adapt Authoring tool. 

Occurs when _ariaLevel exists and its assigned the default value. Affects subheadings in component (when override exists and set to 0(zero)